### PR TITLE
Remove choco instructions from `develop-logseq-on-windows.md`

### DIFF
--- a/docs/develop-logseq-on-windows.md
+++ b/docs/develop-logseq-on-windows.md
@@ -17,26 +17,13 @@ Winget is a package manager installed by default on windows.
 
 An installer for clojure is available from [casselc/clj-msi](https://github.com/casselc/clj-msi/releases/)
 
-## [chocolatey](https://chocolatey.org/)
-
-```
-choco install nvm
-nvm install 18
-nvm use 18
-npm install -g yarn
-choco install visualstudio2022community
-choco install javaruntime
-choco install clojure
-```
-
-
 ## [scoop](https://scoop.sh/)
 
 ```
 scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure
 scoop bucket add extras
 scoop bucket add java
-scoop install java/openjdk clojure clj-deps babashka leiningen nodejs-lts
+scoop install java/openjdk clj-deps babashka leiningen nodejs-lts
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Following up on https://github.com/logseq/logseq/pull/8857:
> - re-add scoop and choco instructions (these are untested)

The choco instructions do not work; more specifically, the `choco install clojure` command does not provide the `clojure` CLI utility:
  ```
  C:\dev\logseq>yarn watch
  yarn run v1.22.19
  $ run-p gulp:watch cljs:watch
  $ gulp watch
  $ clojure -M:cljs watch app electron
  'clojure' is not recognized as an internal or external command
  ```

After running the the scoop install commands, it works OK:
  ```
  C:\dev\logseq>yarn watch
  yarn run v1.22.19
  $ run-p gulp:watch cljs:watch
  $ gulp watch
  $ clojure -M:cljs watch app electron
  Downloading: org/clojure/clojurescript/1.11.54/clojurescript-1.11.54.pom from central
  Downloading: cider/cider-nrepl/0.29.0/cider-nrepl-0.29.0.pom from clojars
  Downloading: org/clojars/knubie/cljs-run-test/1.0.1/cljs-run-test-1.0.1.pom from clojars
  [11:19:49] Using gulpfile C:\dev\logseq\gulpfile.js
  [11:19:49] Starting 'watch'...
  ```

Looks like scoop adds a `clojure.exe` shim, which the choco package does not:
![image](https://github.com/djm2k/logseq/assets/36978885/40d5d5e4-2916-4e6d-a4c5-ba9036cc8db0)
